### PR TITLE
Update api keys, typos, writing style

### DIFF
--- a/api-reference.md
+++ b/api-reference.md
@@ -4,7 +4,7 @@ Mapzen basemaps offer several global properties to customize and extend the map.
 
 Not every basemap supports the full set of resources and the default styling of these assets is customized per Mapzen map style. See [Styles](styles.md) for what's supported.
 
-As the basemaps are still in active development we recommend pegging an import to a specific major version, eg: `6`. See the [versioning](versioning.md) doc for more details.
+As the basemaps are still in active development, Mapzen recommends pegging an import to a specific major version, such as `6`. See the [versioning](versioning.md) doc for more details.
 
 ## Mapzen API keys
 
@@ -22,7 +22,7 @@ Example **Tangram YAML** usage:
 import: https://mapzen.com/carto/refill-style/6/refill-style.yaml
 
 global:
-    sdk_mapzen_api_key: mapzen-xxxxxx
+    sdk_mapzen_api_key: your-mapzen-api-key
 ```
 
 Example **Tangram JS** usage:
@@ -31,14 +31,14 @@ Example **Tangram JS** usage:
 var layer = Tangram.leafletLayer({
     scene: {
       import: 'https://mapzen.com/carto/refill-style/6/refill-style.yaml',
-      global: { sdk_mapzen_api_key: 'mapzen-xxxxxx' }
+      global: { sdk_mapzen_api_key: 'your-mapzen-api-key' }
     });
 ```
 
 Example **Mapzen.js** usage (all services):
 
 ```
-L.Mapzen.apiKey = 'mapzen-xxxxxx';
+L.Mapzen.apiKey = 'your-mapzen-api-key';
 
 var map = L.Mapzen.map('map', {
   center: [40.8041, -124.1506],
@@ -63,7 +63,7 @@ var map = L.Mapzen.map('map', {
     scene: {
       import: L.Mapzen.BasemapStyles.Refill,
       global: {
-        sdk_mapzen_api_key: 'mapzen-xxxxxx'
+        sdk_mapzen_api_key: 'your-mapzen-api-key'
       }
     }
   }
@@ -76,7 +76,7 @@ Example **Tangram ES** usage:
 map->loadScene(
     "https://mapzen.com/carto/refill-style/6/refill-style.yaml",
     false,
-    { "global.sdk_mapzen_api_key", "mapzen-xxxxxx" }
+    { "global.sdk_mapzen_api_key", "your-mapzen-api-key" }
 );
 ```
 

--- a/get-started.md
+++ b/get-started.md
@@ -7,7 +7,7 @@ https://mapzen.com/documentation/tangram/Javascript-API/) or [mapzen.js](https:/
 
 ## Add a basemap to a project
 
-We offer two convenient methods to incorporate Mapzen basemaps into your project:
+There are two convenient methods to incorporate Mapzen basemaps into your project:
 
 ### mapzen.js
 
@@ -16,7 +16,7 @@ We offer two convenient methods to incorporate Mapzen basemaps into your project
 For example:
 
 ```
-L.Mapzen.apiKey = 'mapzen-xxxxxx';
+L.Mapzen.apiKey = 'your-mapzen-api-key';
 
 var map = L.Mapzen.map('map', {
   tangramOptions: {
@@ -66,7 +66,7 @@ Tangram's scene import syntax ([documentation](https://mapzen.com/documentation/
 import: https://mapzen.com/carto/refill-style/6/refill-style.yaml
 
 global:
-    sdk_mapzen_api_key: mapzen-xxxxxxx
+    sdk_mapzen_api_key: your-mapzen-api-key
 ```
 
 Scene files and related assets are available for use in Tangram and Leaflet directly via the Mapzen CDN.

--- a/styles.md
+++ b/styles.md
@@ -1,12 +1,12 @@
-# Basemap Styles
+# Basemap styles
 
 Use gorgeous 2D and 3D basemap styles created by Mapzen's expert cartographers for Tangram.
 
-As Mapzen's basemap styles are still in active development we recommend peggging an import to a specific **MAJOR** version, eg: `7`, so you enjoy any minor and patch updates but are ensured of stable named scene elements.
+As Mapzen's basemap styles are still in active development, you should peg an import to a specific **MAJOR** version, such as `7`, so you enjoy any minor and patch updates but are ensured of stable named scene elements.
 
-We only recommend pegging to the **LATEST** vesion if you are not modifying documented API scene elements.
+You should only peg to the **LATEST** version if you are not modifying documented API scene elements.
 
-Becuase each style imports additional resources, we provide a scene bundle in `.zip` format which includes the scene yaml, image, font, and any other required imports.
+Because each style imports additional resources, we provide a scene bundle in `.zip` format which includes the scene yaml, image, font, and any other required imports.
 
 All of Mapzen basemap styles support:
 
@@ -28,8 +28,7 @@ Some Mapzen basemap styles support:
 
 ![Bubble Wrap](./img/bubble-wrap-style.png)
 
-A full-featured wayfinding style loaded with helpful icons for points of interest. See it
- in action in our very own [Eraser Map on Android](https://mapzen.com/blog/erasermap-beta/).
+A full-featured wayfinding style loaded with helpful icons for points of interest.
 
 **View Bubble Wrap:** [default](https://mapzen.com/products/maps/bubble-wrap) | [more labels](https://mapzen.com/products/maps/bubble-wrap/more-labels) | [no labels](https://mapzen.com/products/maps/bubble-wrap/no-labels)
 
@@ -95,7 +94,7 @@ Current **MAJOR** versioned release (includes any minor and patch updates):
 
 ![Tron](./img/tron-style.gif)
 
-Will autonomous cars dream as they charge overnight? We’re pushing mapping to new extremes with Tron, and it will push your GPU and fan to the limit.
+Will autonomous cars dream as they charge overnight? Mapzen is pushing mapping to new extremes with Tron, and it will push your GPU and fan to the limit.
 
 **View Tron:** [default](https://mapzen.com/products/maps/tron) | [more labels](https://mapzen.com/products/maps/tron/more-labels) | [no labels](https://mapzen.com/products/maps/tron/no-labels)
 

--- a/themes.md
+++ b/themes.md
@@ -31,7 +31,7 @@ var layer = Tangram.leafletLayer({
           import: [
             'https://mapzen.com/carto/refill-style/7/refill-style.zip',
             'https://mapzen.com/carto/refill-style/7/themes/pink-yellow.zip'],
-          global: { 'sdk_mapzen_api_key': 'mapzen-xxxxxx' } },
+          global: { 'sdk_mapzen_api_key': 'your-mapzen-api-key' } },
         attribution: '<a href="https://mapzen.com/tangram" target="_blank">Tangram</a>, &copy; OSM contributors'
     });
 ```
@@ -39,7 +39,7 @@ var layer = Tangram.leafletLayer({
 Example **mapzen.js** usage:
 
 ```
-L.Mapzen.apiKey = 'mapzen-xxxxxx';
+L.Mapzen.apiKey = 'your-mapzen-api-key';
 
 var map = L.Mapzen.map('map', {
   center: [40.8041, -124.1506],


### PR DESCRIPTION
This updates the placeholder to "your-mapzen-api-key". I also found a few typos and style changes (to remove "we" and "eg"), and a link to Eraser Map that I figured we should remove while that app is  being removed from the Play store.

Master checklist: https://github.com/mapzen/documentation/issues/310